### PR TITLE
feat(membership): add perk usage detail API and related models

### DIFF
--- a/docs/membership.md
+++ b/docs/membership.md
@@ -126,6 +126,52 @@ Represents a period of time with a unit and value.
 | `unit`     | google.type.CalendarPeriod | The unit of time for this period              |
 | `value`    | int32                      | The value of the period in the specified unit |
 
+### 4. IncludeBenefitView
+
+Represents a membership benefit view with usage details.
+
+#### Fields
+
+| Field Name           | Type                          | Description                              |
+|----------------------|-------------------------------|------------------------------------------|
+| `id`                 | string                        | History ID                               |
+| `membership_id`      | string                        | Membership identifier                    |
+| `total_quantity`     | int32                         | Total quantity                           |
+| `remaining_quantity` | int32                         | Remaining quantity                       |
+| `is_limited`         | bool                          | Whether the benefit is limited           |
+| `redeem_time`        | google.protobuf.Timestamp     | Time when the benefit was redeemed       |
+| `item_details`       | repeated RedeemItemDetailView | Details of items in the benefit          |
+| `is_all`             | bool                          | Whether the benefit applies to all items |
+| `discount_unit`      | enum DiscountUnit             | Unit of discount (percent or numerical)  |
+| `discount_value`     | double                        | Value of the discount                    |
+
+#### RedeemItemDetailView
+
+| Field Name  | Type              | Description                           |
+|-------------|-------------------|---------------------------------------|
+| `item_id`   | string            | Item identifier                       |
+| `item_name` | string            | Item name                             |
+| `price`     | google.type.Money | Item amount                           |
+| `item_type` | enum TargetType   | Type of item (service, product, etc.) |
+
+#### TargetType Enum
+
+| Value                     | Description             |
+|---------------------------|-------------------------|
+| `TARGET_TYPE_UNSPECIFIED` | Unspecified target type |
+| `SERVICE`                 | Service                 |
+| `ADDON`                   | Add-on                  |
+| `PRODUCT`                 | Product                 |
+| `PACKAGE`                 | Package                 |
+
+#### DiscountUnit Enum
+
+| Value              | Description           |
+|--------------------|-----------------------|
+| `UNIT_UNSPECIFIED` | Unspecified unit      |
+| `PERCENT`          | Percentage discount   |
+| `NUMERICAL`        | Fixed amount discount |
+
 ---
 
 ## 📈 4. Typical Usage Flow
@@ -237,30 +283,76 @@ status to facilitate targeted queries.
 - `INVALID_ARGUMENT`: Pagination parameters are invalid
 - `PERMISSION_DENIED`: Permission denied
 
+### 3. GetPerkUsageDetail (`GetPerkUsageDetail`)
+
+- **Method**: `GetPerkUsageDetail`
+- **HTTP Method**: POST
+- **Path**: `/v1/memberships/perkUsageDetail`
+
+#### ✅ Functionality:
+
+Retrieves detailed information about perk usage for a specific membership and customer. This includes both included
+benefits and discount benefits that are associated with the membership.
+
+#### 🎯 Use Cases:
+
+- View detailed perk usage information for a customer's membership
+- Check remaining quantities of service benefits
+- Review discount benefits available to a customer
+
+#### 🔧 Request Parameters:
+
+| Field Name     | Type   | Required | Description                      |
+|----------------|--------|----------|----------------------------------|
+| `filter`       | Filter | No       | Optional filters for the request |
+| `companyId`    | string | Yes      | Company ID                       |
+| `membershipId` | string | Yes      | Membership ID                    |
+| `customerId`   | string | Yes      | Customer ID                      |
+
+##### Filter Object
+
+| Field Name            | Type                      | Required | Description         |
+|-----------------------|---------------------------|----------|---------------------|
+| `validity_start_time` | google.protobuf.Timestamp | No       | Validity start time |
+
+#### 📌 Return Value:
+
+| Field Name          | Type                      | Description           |
+|---------------------|---------------------------|-----------------------|
+| `included_benefits` | Array(IncludeBenefitView) | The included benefits |
+| `discount_benefits` | Array(IncludeBenefitView) | Discount benefits     |
+
+#### ⚠️ Error Codes:
+
+- `INVALID_ARGUMENT`: Request parameters are invalid
+- `NOT_FOUND`: Membership or customer not found
+- `PERMISSION_DENIED`: Permission denied
+
 ---
 
 ## 🧪 6. Usage Examples
 
 ### Example 1: ListMemberships
 
-```json
+``json
 {
-  "pagination": {
-    "pageSize": 20
-  },
-  "companyId": "cmp_001",
-  "filter": {
-    "name_like": "gold",
-    "statuses": [
-      "ACTIVE"
-    ]
-  }
+"pagination": {
+"pageSize": 20
+},
+"companyId": "cmp_001",
+"filter": {
+"name_like": "gold",
+"statuses": [
+"ACTIVE"
+]
 }
+}
+
 ```
 
 ### Example 2: ListSubscriptions
 
-```json
+``json
 {
   "pagination": {
     "pageSize": 20
@@ -276,6 +368,62 @@ status to facilitate targeted queries.
       "TRIAL"
     ]
   }
+}
+```
+
+### Example 3: GetPerkUsageDetail
+
+``json
+{
+"companyId": "cmp_001",
+"membershipId": "mem_abc123",
+"customerId": "cus_xyz789"
+}
+
+```
+
+Response:
+``json
+{
+  "included_benefits": [
+    {
+      "id": "inc_001",
+      "membership_id": "mem_abc123",
+      "total_quantity": 10,
+      "remaining_quantity": 5,
+      "is_limited": true,
+      "redeem_time": "2023-01-15T10:00:00Z",
+      "item_details": [
+        {
+          "item_id": "srv_001",
+          "item_name": "Basic Grooming",
+          "price": {
+            "currencyCode": "USD",
+            "units": 50,
+            "nanos": 0
+          },
+          "item_type": "SERVICE"
+        }
+      ],
+      "is_all": false,
+      "discount_unit": "UNIT_UNSPECIFIED",
+      "discount_value": 0
+    }
+  ],
+  "discount_benefits": [
+    {
+      "id": "disc_001",
+      "membership_id": "mem_abc123",
+      "total_quantity": 0,
+      "remaining_quantity": 0,
+      "is_limited": false,
+      "redeem_time": "2023-01-15T10:00:00Z",
+      "item_details": [],
+      "is_all": true,
+      "discount_unit": "PERCENT",
+      "discount_value": 15.0
+    }
+  ]
 }
 ```
 

--- a/docs/openapi/moego/business/membership/v1/membership_service.swagger.json
+++ b/docs/openapi/moego/business/membership/v1/membership_service.swagger.json
@@ -16,6 +16,40 @@
     "application/json"
   ],
   "paths": {
+    "/v1/memberships/perkUsageDetail": {
+      "post": {
+        "summary": "GetPerkUsageDetail retrieves detailed information about perk usage for a specific membership.",
+        "description": "Possible errors:\n- INVALID_ARGUMENT if the request parameters are invalid\n- NOT_FOUND if the membership or customer is not found\n- PERMISSION_DENIED if the caller lacks access rights",
+        "operationId": "MembershipService_GetPerkUsageDetail",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetPerkUsageDetailResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetPerkUsageDetailRequest"
+            }
+          }
+        ],
+        "tags": [
+          "moego.business.membership.v1.MembershipService"
+        ]
+      }
+    },
     "/v1/memberships/subscriptions:list": {
       "post": {
         "summary": "ListSubscriptions retrieves a paginated list of subscriptions based on specified criteria.\nSupports filtering by customer, membership, and status to facilitate targeted queries.",
@@ -88,6 +122,34 @@
     }
   },
   "definitions": {
+    "IncludeBenefitViewRedeemItemDetailView": {
+      "type": "object",
+      "properties": {
+        "itemId": {
+          "type": "string",
+          "title": "item id"
+        },
+        "itemName": {
+          "type": "string",
+          "title": "item name"
+        },
+        "price": {
+          "$ref": "#/definitions/typeMoney",
+          "title": "item amount"
+        },
+        "itemType": {
+          "$ref": "#/definitions/v1TargetType",
+          "title": "item type"
+        }
+      },
+      "title": "item detail def",
+      "x-go-type": {
+        "import": {
+          "package": "github.com/MoeGolibrary/moegoapis/genproto/go/business/membership/v1/membershippb"
+        },
+        "type": "RedeemItemDetailView"
+      }
+    },
     "googlerpcStatus": {
       "type": "object",
       "properties": {
@@ -268,6 +330,156 @@
           "package": "github.com/MoeGolibrary/moegoapis/genproto/go/business/setting/v1/settingpb"
         },
         "type": "CustomizedBreed"
+      }
+    },
+    "v1DiscountUnit": {
+      "type": "string",
+      "enum": [
+        "UNIT_UNSPECIFIED",
+        "PERCENT",
+        "NUMERICAL"
+      ],
+      "default": "UNIT_UNSPECIFIED",
+      "description": "DiscountUnit represents the unit of discount for membership benefits.\n\n - UNIT_UNSPECIFIED: unspecified\n - PERCENT: percent\n - NUMERICAL: numerical"
+    },
+    "v1GetPerkUsageDetailRequest": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/v1GetPerkUsageDetailRequestFilter",
+          "x-nullable": true,
+          "title": "Optional filter"
+        },
+        "companyId": {
+          "type": "string",
+          "title": "The company identifier"
+        },
+        "membershipId": {
+          "type": "string",
+          "title": "The membership identifier"
+        },
+        "customerId": {
+          "type": "string",
+          "title": "The customer identifier"
+        }
+      },
+      "title": "The request message for getting perk usage detail",
+      "required": [
+        "companyId",
+        "membershipId",
+        "customerId"
+      ],
+      "x-go-type": {
+        "import": {
+          "package": "github.com/MoeGolibrary/moegoapis/genproto/go/business/membership/v1/membershippb"
+        },
+        "type": "GetPerkUsageDetailRequest"
+      }
+    },
+    "v1GetPerkUsageDetailRequestFilter": {
+      "type": "object",
+      "properties": {
+        "validityStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "title": "Validity start time"
+        }
+      },
+      "title": "Filter parameters",
+      "x-go-type": {
+        "import": {
+          "package": "github.com/MoeGolibrary/moegoapis/genproto/go/business/membership/v1/membershippb"
+        },
+        "type": "Filter"
+      }
+    },
+    "v1GetPerkUsageDetailResponse": {
+      "type": "object",
+      "properties": {
+        "includedBenefits": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1IncludeBenefitView"
+          },
+          "title": "The included benefits"
+        },
+        "discountBenefits": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1IncludeBenefitView"
+          },
+          "title": "Discount benefits"
+        }
+      },
+      "title": "The response message for getting perk usage detail",
+      "x-go-type": {
+        "import": {
+          "package": "github.com/MoeGolibrary/moegoapis/genproto/go/business/membership/v1/membershippb"
+        },
+        "type": "GetPerkUsageDetailResponse"
+      }
+    },
+    "v1IncludeBenefitView": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "history id"
+        },
+        "membershipId": {
+          "type": "string",
+          "title": "membership id"
+        },
+        "totalQuantity": {
+          "type": "integer",
+          "format": "int32",
+          "title": "quantity"
+        },
+        "remainingQuantity": {
+          "type": "integer",
+          "format": "int32",
+          "title": "remaining quantity"
+        },
+        "isLimited": {
+          "type": "boolean",
+          "title": "is limited"
+        },
+        "redeemTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "redeem time"
+        },
+        "itemDetails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/IncludeBenefitViewRedeemItemDetailView"
+          },
+          "title": "item details"
+        },
+        "isAll": {
+          "type": "boolean",
+          "title": "is all"
+        },
+        "discountUnit": {
+          "$ref": "#/definitions/v1DiscountUnit",
+          "title": "discount unit"
+        },
+        "discountValue": {
+          "type": "number",
+          "format": "double",
+          "title": "discount value"
+        }
+      },
+      "description": "IncludeBenefitView represents a membership benefit view.",
+      "x-go-type": {
+        "import": {
+          "package": "github.com/MoeGolibrary/moegoapis/genproto/go/business/membership/v1/membershippb"
+        },
+        "type": "IncludeBenefitView"
       }
     },
     "v1ListMembershipsRequest": {
@@ -703,6 +915,18 @@
       ],
       "default": "STATUS_UNSPECIFIED",
       "description": "Status represents the current state of a subscription.\n\n - STATUS_UNSPECIFIED: STATUS_UNSPECIFIED indicates an unknown or invalid status.\n - TRIAL: TRIAL indicates the subscription is in trial period.\n - PENDING: PENDING indicates the subscription is waiting for the first charge result.\n - ACTIVE: ACTIVE indicates the subscription is charged and in validity period.\nCancel in validity period will not change the status,\njust change the cancel_at_period_end value to true.\n - GRACE: GRACE indicates the subscription is in grace period.\n - EXPIRED: EXPIRED indicates the subscription is expired and out of validity period.\n - CANCELLED: CANCELLED indicates the subscription is manually cancelled and out of validity period.\n - PAUSED: PAUSED indicates the subscription is currently paused.\n - INCOMPLETE: INCOMPLETE indicates the subscription is not completed."
+    },
+    "v1TargetType": {
+      "type": "string",
+      "enum": [
+        "TARGET_TYPE_UNSPECIFIED",
+        "SERVICE",
+        "ADDON",
+        "PRODUCT",
+        "PACKAGE"
+      ],
+      "default": "TARGET_TYPE_UNSPECIFIED",
+      "description": "TargetType represents the type of target for membership benefits.\n\n - TARGET_TYPE_UNSPECIFIED: unspecified\n - SERVICE: service\n - ADDON: add on\n - PRODUCT: product\n - PACKAGE: package"
     },
     "v1TimePeriod": {
       "type": "object",

--- a/genproto/go/business/membership/v1/membershippb/membership.pb.go
+++ b/genproto/go/business/membership/v1/membershippb/membership.pb.go
@@ -29,6 +29,120 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// TargetType represents the type of target for membership benefits.
+type TargetType int32
+
+const (
+	// unspecified
+	TargetType_TARGET_TYPE_UNSPECIFIED TargetType = 0
+	// service
+	TargetType_SERVICE TargetType = 1
+	// add on
+	TargetType_ADDON TargetType = 2
+	// product
+	TargetType_PRODUCT TargetType = 3
+	// package
+	TargetType_PACKAGE TargetType = 4
+)
+
+// Enum value maps for TargetType.
+var (
+	TargetType_name = map[int32]string{
+		0: "TARGET_TYPE_UNSPECIFIED",
+		1: "SERVICE",
+		2: "ADDON",
+		3: "PRODUCT",
+		4: "PACKAGE",
+	}
+	TargetType_value = map[string]int32{
+		"TARGET_TYPE_UNSPECIFIED": 0,
+		"SERVICE":                 1,
+		"ADDON":                   2,
+		"PRODUCT":                 3,
+		"PACKAGE":                 4,
+	}
+)
+
+func (x TargetType) Enum() *TargetType {
+	p := new(TargetType)
+	*p = x
+	return p
+}
+
+func (x TargetType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TargetType) Descriptor() protoreflect.EnumDescriptor {
+	return file_moego_business_membership_v1_membership_proto_enumTypes[0].Descriptor()
+}
+
+func (TargetType) Type() protoreflect.EnumType {
+	return &file_moego_business_membership_v1_membership_proto_enumTypes[0]
+}
+
+func (x TargetType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TargetType.Descriptor instead.
+func (TargetType) EnumDescriptor() ([]byte, []int) {
+	return file_moego_business_membership_v1_membership_proto_rawDescGZIP(), []int{0}
+}
+
+// DiscountUnit represents the unit of discount for membership benefits.
+type DiscountUnit int32
+
+const (
+	// unspecified
+	DiscountUnit_UNIT_UNSPECIFIED DiscountUnit = 0
+	// percent
+	DiscountUnit_PERCENT DiscountUnit = 1
+	// numerical
+	DiscountUnit_NUMERICAL DiscountUnit = 2
+)
+
+// Enum value maps for DiscountUnit.
+var (
+	DiscountUnit_name = map[int32]string{
+		0: "UNIT_UNSPECIFIED",
+		1: "PERCENT",
+		2: "NUMERICAL",
+	}
+	DiscountUnit_value = map[string]int32{
+		"UNIT_UNSPECIFIED": 0,
+		"PERCENT":          1,
+		"NUMERICAL":        2,
+	}
+)
+
+func (x DiscountUnit) Enum() *DiscountUnit {
+	p := new(DiscountUnit)
+	*p = x
+	return p
+}
+
+func (x DiscountUnit) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DiscountUnit) Descriptor() protoreflect.EnumDescriptor {
+	return file_moego_business_membership_v1_membership_proto_enumTypes[1].Descriptor()
+}
+
+func (DiscountUnit) Type() protoreflect.EnumType {
+	return &file_moego_business_membership_v1_membership_proto_enumTypes[1]
+}
+
+func (x DiscountUnit) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DiscountUnit.Descriptor instead.
+func (DiscountUnit) EnumDescriptor() ([]byte, []int) {
+	return file_moego_business_membership_v1_membership_proto_rawDescGZIP(), []int{1}
+}
+
 // Status represents the current state of a membership plan.
 type Membership_Status int32
 
@@ -67,11 +181,11 @@ func (x Membership_Status) String() string {
 }
 
 func (Membership_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_moego_business_membership_v1_membership_proto_enumTypes[0].Descriptor()
+	return file_moego_business_membership_v1_membership_proto_enumTypes[2].Descriptor()
 }
 
 func (Membership_Status) Type() protoreflect.EnumType {
-	return &file_moego_business_membership_v1_membership_proto_enumTypes[0]
+	return &file_moego_business_membership_v1_membership_proto_enumTypes[2]
 }
 
 func (x Membership_Status) Number() protoreflect.EnumNumber {
@@ -120,11 +234,11 @@ func (x Membership_Source) String() string {
 }
 
 func (Membership_Source) Descriptor() protoreflect.EnumDescriptor {
-	return file_moego_business_membership_v1_membership_proto_enumTypes[1].Descriptor()
+	return file_moego_business_membership_v1_membership_proto_enumTypes[3].Descriptor()
 }
 
 func (Membership_Source) Type() protoreflect.EnumType {
-	return &file_moego_business_membership_v1_membership_proto_enumTypes[1]
+	return &file_moego_business_membership_v1_membership_proto_enumTypes[3]
 }
 
 func (x Membership_Source) Number() protoreflect.EnumNumber {
@@ -199,11 +313,11 @@ func (x Subscription_Status) String() string {
 }
 
 func (Subscription_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_moego_business_membership_v1_membership_proto_enumTypes[2].Descriptor()
+	return file_moego_business_membership_v1_membership_proto_enumTypes[4].Descriptor()
 }
 
 func (Subscription_Status) Type() protoreflect.EnumType {
-	return &file_moego_business_membership_v1_membership_proto_enumTypes[2]
+	return &file_moego_business_membership_v1_membership_proto_enumTypes[4]
 }
 
 func (x Subscription_Status) Number() protoreflect.EnumNumber {
@@ -733,6 +847,206 @@ func (x *TimePeriod) GetValue() int32 {
 	return 0
 }
 
+// IncludeBenefitView represents a membership benefit view.
+type IncludeBenefitView struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// history id
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// membership id
+	MembershipId string `protobuf:"bytes,2,opt,name=membership_id,json=membershipId,proto3" json:"membership_id,omitempty"`
+	// quantity
+	TotalQuantity int32 `protobuf:"varint,3,opt,name=total_quantity,json=totalQuantity,proto3" json:"total_quantity,omitempty"`
+	// remaining quantity
+	RemainingQuantity int32 `protobuf:"varint,4,opt,name=remaining_quantity,json=remainingQuantity,proto3" json:"remaining_quantity,omitempty"`
+	// is limited
+	IsLimited bool `protobuf:"varint,5,opt,name=is_limited,json=isLimited,proto3" json:"is_limited,omitempty"`
+	// redeem time
+	RedeemTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=redeem_time,json=redeemTime,proto3" json:"redeem_time,omitempty"`
+	// item details
+	ItemDetails []*IncludeBenefitView_RedeemItemDetailView `protobuf:"bytes,7,rep,name=item_details,json=itemDetails,proto3" json:"item_details,omitempty"`
+	// is all
+	IsAll bool `protobuf:"varint,8,opt,name=is_all,json=isAll,proto3" json:"is_all,omitempty"`
+	// discount unit
+	DiscountUnit DiscountUnit `protobuf:"varint,9,opt,name=discount_unit,json=discountUnit,proto3,enum=moego.business.membership.v1.DiscountUnit" json:"discount_unit,omitempty"`
+	// discount value
+	DiscountValue float64 `protobuf:"fixed64,10,opt,name=discount_value,json=discountValue,proto3" json:"discount_value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IncludeBenefitView) Reset() {
+	*x = IncludeBenefitView{}
+	mi := &file_moego_business_membership_v1_membership_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IncludeBenefitView) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IncludeBenefitView) ProtoMessage() {}
+
+func (x *IncludeBenefitView) ProtoReflect() protoreflect.Message {
+	mi := &file_moego_business_membership_v1_membership_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IncludeBenefitView.ProtoReflect.Descriptor instead.
+func (*IncludeBenefitView) Descriptor() ([]byte, []int) {
+	return file_moego_business_membership_v1_membership_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *IncludeBenefitView) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *IncludeBenefitView) GetMembershipId() string {
+	if x != nil {
+		return x.MembershipId
+	}
+	return ""
+}
+
+func (x *IncludeBenefitView) GetTotalQuantity() int32 {
+	if x != nil {
+		return x.TotalQuantity
+	}
+	return 0
+}
+
+func (x *IncludeBenefitView) GetRemainingQuantity() int32 {
+	if x != nil {
+		return x.RemainingQuantity
+	}
+	return 0
+}
+
+func (x *IncludeBenefitView) GetIsLimited() bool {
+	if x != nil {
+		return x.IsLimited
+	}
+	return false
+}
+
+func (x *IncludeBenefitView) GetRedeemTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RedeemTime
+	}
+	return nil
+}
+
+func (x *IncludeBenefitView) GetItemDetails() []*IncludeBenefitView_RedeemItemDetailView {
+	if x != nil {
+		return x.ItemDetails
+	}
+	return nil
+}
+
+func (x *IncludeBenefitView) GetIsAll() bool {
+	if x != nil {
+		return x.IsAll
+	}
+	return false
+}
+
+func (x *IncludeBenefitView) GetDiscountUnit() DiscountUnit {
+	if x != nil {
+		return x.DiscountUnit
+	}
+	return DiscountUnit_UNIT_UNSPECIFIED
+}
+
+func (x *IncludeBenefitView) GetDiscountValue() float64 {
+	if x != nil {
+		return x.DiscountValue
+	}
+	return 0
+}
+
+// item detail def
+type IncludeBenefitView_RedeemItemDetailView struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// item id
+	ItemId string `protobuf:"bytes,1,opt,name=item_id,json=itemId,proto3" json:"item_id,omitempty"`
+	// item name
+	ItemName string `protobuf:"bytes,2,opt,name=item_name,json=itemName,proto3" json:"item_name,omitempty"`
+	// item amount
+	Price *money.Money `protobuf:"bytes,3,opt,name=price,proto3" json:"price,omitempty"`
+	// item type
+	ItemType      TargetType `protobuf:"varint,4,opt,name=item_type,json=itemType,proto3,enum=moego.business.membership.v1.TargetType" json:"item_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IncludeBenefitView_RedeemItemDetailView) Reset() {
+	*x = IncludeBenefitView_RedeemItemDetailView{}
+	mi := &file_moego_business_membership_v1_membership_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IncludeBenefitView_RedeemItemDetailView) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IncludeBenefitView_RedeemItemDetailView) ProtoMessage() {}
+
+func (x *IncludeBenefitView_RedeemItemDetailView) ProtoReflect() protoreflect.Message {
+	mi := &file_moego_business_membership_v1_membership_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IncludeBenefitView_RedeemItemDetailView.ProtoReflect.Descriptor instead.
+func (*IncludeBenefitView_RedeemItemDetailView) Descriptor() ([]byte, []int) {
+	return file_moego_business_membership_v1_membership_proto_rawDescGZIP(), []int{3, 0}
+}
+
+func (x *IncludeBenefitView_RedeemItemDetailView) GetItemId() string {
+	if x != nil {
+		return x.ItemId
+	}
+	return ""
+}
+
+func (x *IncludeBenefitView_RedeemItemDetailView) GetItemName() string {
+	if x != nil {
+		return x.ItemName
+	}
+	return ""
+}
+
+func (x *IncludeBenefitView_RedeemItemDetailView) GetPrice() *money.Money {
+	if x != nil {
+		return x.Price
+	}
+	return nil
+}
+
+func (x *IncludeBenefitView_RedeemItemDetailView) GetItemType() TargetType {
+	if x != nil {
+		return x.ItemType
+	}
+	return TargetType_TARGET_TYPE_UNSPECIFIED
+}
+
 var File_moego_business_membership_v1_membership_proto protoreflect.FileDescriptor
 
 const file_moego_business_membership_v1_membership_proto_rawDesc = "" +
@@ -816,7 +1130,37 @@ const file_moego_business_membership_v1_membership_proto_rawDesc = "" +
 	"\n" +
 	"TimePeriod\x12/\n" +
 	"\x04unit\x18\x01 \x01(\x0e2\x1b.google.type.CalendarPeriodR\x04unit\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05valueB\x99\x01\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value\"\xb4\x05\n" +
+	"\x12IncludeBenefitView\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12#\n" +
+	"\rmembership_id\x18\x02 \x01(\tR\fmembershipId\x12%\n" +
+	"\x0etotal_quantity\x18\x03 \x01(\x05R\rtotalQuantity\x12-\n" +
+	"\x12remaining_quantity\x18\x04 \x01(\x05R\x11remainingQuantity\x12\x1d\n" +
+	"\n" +
+	"is_limited\x18\x05 \x01(\bR\tisLimited\x12;\n" +
+	"\vredeem_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"redeemTime\x12h\n" +
+	"\fitem_details\x18\a \x03(\v2E.moego.business.membership.v1.IncludeBenefitView.RedeemItemDetailViewR\vitemDetails\x12\x15\n" +
+	"\x06is_all\x18\b \x01(\bR\x05isAll\x12O\n" +
+	"\rdiscount_unit\x18\t \x01(\x0e2*.moego.business.membership.v1.DiscountUnitR\fdiscountUnit\x12%\n" +
+	"\x0ediscount_value\x18\n" +
+	" \x01(\x01R\rdiscountValue\x1a\xbd\x01\n" +
+	"\x14RedeemItemDetailView\x12\x17\n" +
+	"\aitem_id\x18\x01 \x01(\tR\x06itemId\x12\x1b\n" +
+	"\titem_name\x18\x02 \x01(\tR\bitemName\x12(\n" +
+	"\x05price\x18\x03 \x01(\v2\x12.google.type.MoneyR\x05price\x12E\n" +
+	"\titem_type\x18\x04 \x01(\x0e2(.moego.business.membership.v1.TargetTypeR\bitemType*[\n" +
+	"\n" +
+	"TargetType\x12\x1b\n" +
+	"\x17TARGET_TYPE_UNSPECIFIED\x10\x00\x12\v\n" +
+	"\aSERVICE\x10\x01\x12\t\n" +
+	"\x05ADDON\x10\x02\x12\v\n" +
+	"\aPRODUCT\x10\x03\x12\v\n" +
+	"\aPACKAGE\x10\x04*@\n" +
+	"\fDiscountUnit\x12\x14\n" +
+	"\x10UNIT_UNSPECIFIED\x10\x00\x12\v\n" +
+	"\aPERCENT\x10\x01\x12\r\n" +
+	"\tNUMERICAL\x10\x02B\x99\x01\n" +
 	"$com.moego.api.business.membership.v1B\x0fMembershipProtoP\x01Z^github.com/MoeGolibrary/moegoapis/genproto/go/business/membership/v1/membershippb;membershippbb\x06proto3"
 
 var (
@@ -831,50 +1175,59 @@ func file_moego_business_membership_v1_membership_proto_rawDescGZIP() []byte {
 	return file_moego_business_membership_v1_membership_proto_rawDescData
 }
 
-var file_moego_business_membership_v1_membership_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_moego_business_membership_v1_membership_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_moego_business_membership_v1_membership_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_moego_business_membership_v1_membership_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_moego_business_membership_v1_membership_proto_goTypes = []any{
-	(Membership_Status)(0),             // 0: moego.business.membership.v1.Membership.Status
-	(Membership_Source)(0),             // 1: moego.business.membership.v1.Membership.Source
-	(Subscription_Status)(0),           // 2: moego.business.membership.v1.Subscription.Status
-	(*Membership)(nil),                 // 3: moego.business.membership.v1.Membership
-	(*Subscription)(nil),               // 4: moego.business.membership.v1.Subscription
-	(*TimePeriod)(nil),                 // 5: moego.business.membership.v1.TimePeriod
-	(*money.Money)(nil),                // 6: google.type.Money
-	(*timestamppb.Timestamp)(nil),      // 7: google.protobuf.Timestamp
-	(dayofweek.DayOfWeek)(0),           // 8: google.type.DayOfWeek
-	(*settingpb.CustomizedBreed)(nil),  // 9: moego.business.setting.v1.CustomizedBreed
-	(*timeofday.TimeOfDay)(nil),        // 10: google.type.TimeOfDay
-	(*interval.Interval)(nil),          // 11: google.type.Interval
-	(calendarperiod.CalendarPeriod)(0), // 12: google.type.CalendarPeriod
+	(TargetType)(0),                                 // 0: moego.business.membership.v1.TargetType
+	(DiscountUnit)(0),                               // 1: moego.business.membership.v1.DiscountUnit
+	(Membership_Status)(0),                          // 2: moego.business.membership.v1.Membership.Status
+	(Membership_Source)(0),                          // 3: moego.business.membership.v1.Membership.Source
+	(Subscription_Status)(0),                        // 4: moego.business.membership.v1.Subscription.Status
+	(*Membership)(nil),                              // 5: moego.business.membership.v1.Membership
+	(*Subscription)(nil),                            // 6: moego.business.membership.v1.Subscription
+	(*TimePeriod)(nil),                              // 7: moego.business.membership.v1.TimePeriod
+	(*IncludeBenefitView)(nil),                      // 8: moego.business.membership.v1.IncludeBenefitView
+	(*IncludeBenefitView_RedeemItemDetailView)(nil), // 9: moego.business.membership.v1.IncludeBenefitView.RedeemItemDetailView
+	(*money.Money)(nil),                             // 10: google.type.Money
+	(*timestamppb.Timestamp)(nil),                   // 11: google.protobuf.Timestamp
+	(dayofweek.DayOfWeek)(0),                        // 12: google.type.DayOfWeek
+	(*settingpb.CustomizedBreed)(nil),               // 13: moego.business.setting.v1.CustomizedBreed
+	(*timeofday.TimeOfDay)(nil),                     // 14: google.type.TimeOfDay
+	(*interval.Interval)(nil),                       // 15: google.type.Interval
+	(calendarperiod.CalendarPeriod)(0),              // 16: google.type.CalendarPeriod
 }
 var file_moego_business_membership_v1_membership_proto_depIdxs = []int32{
-	0,  // 0: moego.business.membership.v1.Membership.status:type_name -> moego.business.membership.v1.Membership.Status
-	6,  // 1: moego.business.membership.v1.Membership.price:type_name -> google.type.Money
-	5,  // 2: moego.business.membership.v1.Membership.billing_cycle_period:type_name -> moego.business.membership.v1.TimePeriod
-	7,  // 3: moego.business.membership.v1.Membership.created_time:type_name -> google.protobuf.Timestamp
-	7,  // 4: moego.business.membership.v1.Membership.last_updated_time:type_name -> google.protobuf.Timestamp
-	7,  // 5: moego.business.membership.v1.Membership.deleted_time:type_name -> google.protobuf.Timestamp
-	6,  // 6: moego.business.membership.v1.Membership.total_price:type_name -> google.type.Money
-	6,  // 7: moego.business.membership.v1.Membership.total_tax:type_name -> google.type.Money
-	8,  // 8: moego.business.membership.v1.Membership.billing_cycle_day_of_week:type_name -> google.type.DayOfWeek
-	9,  // 9: moego.business.membership.v1.Membership.customized_breeds:type_name -> moego.business.setting.v1.CustomizedBreed
-	1,  // 10: moego.business.membership.v1.Membership.source:type_name -> moego.business.membership.v1.Membership.Source
-	10, // 11: moego.business.membership.v1.Membership.billing_cycle_time_of_day:type_name -> google.type.TimeOfDay
-	6,  // 12: moego.business.membership.v1.Subscription.price:type_name -> google.type.Money
-	7,  // 13: moego.business.membership.v1.Subscription.created_time:type_name -> google.protobuf.Timestamp
-	7,  // 14: moego.business.membership.v1.Subscription.last_updated_time:type_name -> google.protobuf.Timestamp
-	7,  // 15: moego.business.membership.v1.Subscription.deleted_time:type_name -> google.protobuf.Timestamp
-	11, // 16: moego.business.membership.v1.Subscription.validity_period:type_name -> google.type.Interval
-	7,  // 17: moego.business.membership.v1.Subscription.next_billing_date:type_name -> google.protobuf.Timestamp
-	7,  // 18: moego.business.membership.v1.Subscription.expired_time:type_name -> google.protobuf.Timestamp
-	2,  // 19: moego.business.membership.v1.Subscription.status:type_name -> moego.business.membership.v1.Subscription.Status
-	12, // 20: moego.business.membership.v1.TimePeriod.unit:type_name -> google.type.CalendarPeriod
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	2,  // 0: moego.business.membership.v1.Membership.status:type_name -> moego.business.membership.v1.Membership.Status
+	10, // 1: moego.business.membership.v1.Membership.price:type_name -> google.type.Money
+	7,  // 2: moego.business.membership.v1.Membership.billing_cycle_period:type_name -> moego.business.membership.v1.TimePeriod
+	11, // 3: moego.business.membership.v1.Membership.created_time:type_name -> google.protobuf.Timestamp
+	11, // 4: moego.business.membership.v1.Membership.last_updated_time:type_name -> google.protobuf.Timestamp
+	11, // 5: moego.business.membership.v1.Membership.deleted_time:type_name -> google.protobuf.Timestamp
+	10, // 6: moego.business.membership.v1.Membership.total_price:type_name -> google.type.Money
+	10, // 7: moego.business.membership.v1.Membership.total_tax:type_name -> google.type.Money
+	12, // 8: moego.business.membership.v1.Membership.billing_cycle_day_of_week:type_name -> google.type.DayOfWeek
+	13, // 9: moego.business.membership.v1.Membership.customized_breeds:type_name -> moego.business.setting.v1.CustomizedBreed
+	3,  // 10: moego.business.membership.v1.Membership.source:type_name -> moego.business.membership.v1.Membership.Source
+	14, // 11: moego.business.membership.v1.Membership.billing_cycle_time_of_day:type_name -> google.type.TimeOfDay
+	10, // 12: moego.business.membership.v1.Subscription.price:type_name -> google.type.Money
+	11, // 13: moego.business.membership.v1.Subscription.created_time:type_name -> google.protobuf.Timestamp
+	11, // 14: moego.business.membership.v1.Subscription.last_updated_time:type_name -> google.protobuf.Timestamp
+	11, // 15: moego.business.membership.v1.Subscription.deleted_time:type_name -> google.protobuf.Timestamp
+	15, // 16: moego.business.membership.v1.Subscription.validity_period:type_name -> google.type.Interval
+	11, // 17: moego.business.membership.v1.Subscription.next_billing_date:type_name -> google.protobuf.Timestamp
+	11, // 18: moego.business.membership.v1.Subscription.expired_time:type_name -> google.protobuf.Timestamp
+	4,  // 19: moego.business.membership.v1.Subscription.status:type_name -> moego.business.membership.v1.Subscription.Status
+	16, // 20: moego.business.membership.v1.TimePeriod.unit:type_name -> google.type.CalendarPeriod
+	11, // 21: moego.business.membership.v1.IncludeBenefitView.redeem_time:type_name -> google.protobuf.Timestamp
+	9,  // 22: moego.business.membership.v1.IncludeBenefitView.item_details:type_name -> moego.business.membership.v1.IncludeBenefitView.RedeemItemDetailView
+	1,  // 23: moego.business.membership.v1.IncludeBenefitView.discount_unit:type_name -> moego.business.membership.v1.DiscountUnit
+	10, // 24: moego.business.membership.v1.IncludeBenefitView.RedeemItemDetailView.price:type_name -> google.type.Money
+	0,  // 25: moego.business.membership.v1.IncludeBenefitView.RedeemItemDetailView.item_type:type_name -> moego.business.membership.v1.TargetType
+	26, // [26:26] is the sub-list for method output_type
+	26, // [26:26] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_moego_business_membership_v1_membership_proto_init() }
@@ -887,8 +1240,8 @@ func file_moego_business_membership_v1_membership_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_moego_business_membership_v1_membership_proto_rawDesc), len(file_moego_business_membership_v1_membership_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   3,
+			NumEnums:      5,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/genproto/go/business/membership/v1/membershippb/membership_service.pb.go
+++ b/genproto/go/business/membership/v1/membershippb/membership_service.pb.go
@@ -11,6 +11,7 @@ import (
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -271,6 +272,134 @@ func (x *ListSubscriptionsResponse) GetNextPageToken() string {
 	return ""
 }
 
+// The request message for getting perk usage detail
+type GetPerkUsageDetailRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional filter
+	Filter *GetPerkUsageDetailRequest_Filter `protobuf:"bytes,1,opt,name=filter,proto3,oneof" json:"filter,omitempty"`
+	// The company identifier
+	CompanyId string `protobuf:"bytes,2,opt,name=company_id,json=companyId,proto3" json:"company_id,omitempty"`
+	// The membership identifier
+	MembershipId string `protobuf:"bytes,3,opt,name=membership_id,json=membershipId,proto3" json:"membership_id,omitempty"`
+	// The customer identifier
+	CustomerId    string `protobuf:"bytes,4,opt,name=customer_id,json=customerId,proto3" json:"customer_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetPerkUsageDetailRequest) Reset() {
+	*x = GetPerkUsageDetailRequest{}
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPerkUsageDetailRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPerkUsageDetailRequest) ProtoMessage() {}
+
+func (x *GetPerkUsageDetailRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPerkUsageDetailRequest.ProtoReflect.Descriptor instead.
+func (*GetPerkUsageDetailRequest) Descriptor() ([]byte, []int) {
+	return file_moego_business_membership_v1_membership_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GetPerkUsageDetailRequest) GetFilter() *GetPerkUsageDetailRequest_Filter {
+	if x != nil {
+		return x.Filter
+	}
+	return nil
+}
+
+func (x *GetPerkUsageDetailRequest) GetCompanyId() string {
+	if x != nil {
+		return x.CompanyId
+	}
+	return ""
+}
+
+func (x *GetPerkUsageDetailRequest) GetMembershipId() string {
+	if x != nil {
+		return x.MembershipId
+	}
+	return ""
+}
+
+func (x *GetPerkUsageDetailRequest) GetCustomerId() string {
+	if x != nil {
+		return x.CustomerId
+	}
+	return ""
+}
+
+// The response message for getting perk usage detail
+type GetPerkUsageDetailResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The included benefits
+	IncludedBenefits []*IncludeBenefitView `protobuf:"bytes,1,rep,name=included_benefits,json=includedBenefits,proto3" json:"included_benefits,omitempty"`
+	// Discount benefits
+	DiscountBenefits []*IncludeBenefitView `protobuf:"bytes,2,rep,name=discount_benefits,json=discountBenefits,proto3" json:"discount_benefits,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GetPerkUsageDetailResponse) Reset() {
+	*x = GetPerkUsageDetailResponse{}
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPerkUsageDetailResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPerkUsageDetailResponse) ProtoMessage() {}
+
+func (x *GetPerkUsageDetailResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPerkUsageDetailResponse.ProtoReflect.Descriptor instead.
+func (*GetPerkUsageDetailResponse) Descriptor() ([]byte, []int) {
+	return file_moego_business_membership_v1_membership_service_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GetPerkUsageDetailResponse) GetIncludedBenefits() []*IncludeBenefitView {
+	if x != nil {
+		return x.IncludedBenefits
+	}
+	return nil
+}
+
+func (x *GetPerkUsageDetailResponse) GetDiscountBenefits() []*IncludeBenefitView {
+	if x != nil {
+		return x.DiscountBenefits
+	}
+	return nil
+}
+
 // Filter parameters for the membership list
 type ListMembershipsRequest_Filter struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -286,7 +415,7 @@ type ListMembershipsRequest_Filter struct {
 
 func (x *ListMembershipsRequest_Filter) Reset() {
 	*x = ListMembershipsRequest_Filter{}
-	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[4]
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -298,7 +427,7 @@ func (x *ListMembershipsRequest_Filter) String() string {
 func (*ListMembershipsRequest_Filter) ProtoMessage() {}
 
 func (x *ListMembershipsRequest_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[4]
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -346,7 +475,7 @@ type ListSubscriptionsRequest_Filter struct {
 
 func (x *ListSubscriptionsRequest_Filter) Reset() {
 	*x = ListSubscriptionsRequest_Filter{}
-	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[5]
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -358,7 +487,7 @@ func (x *ListSubscriptionsRequest_Filter) String() string {
 func (*ListSubscriptionsRequest_Filter) ProtoMessage() {}
 
 func (x *ListSubscriptionsRequest_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[5]
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -395,11 +524,57 @@ func (x *ListSubscriptionsRequest_Filter) GetStatuses() []Subscription_Status {
 	return nil
 }
 
+// Filter parameters
+type GetPerkUsageDetailRequest_Filter struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Validity start time
+	ValidityStartTime *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=validity_start_time,json=validityStartTime,proto3,oneof" json:"validity_start_time,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GetPerkUsageDetailRequest_Filter) Reset() {
+	*x = GetPerkUsageDetailRequest_Filter{}
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPerkUsageDetailRequest_Filter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPerkUsageDetailRequest_Filter) ProtoMessage() {}
+
+func (x *GetPerkUsageDetailRequest_Filter) ProtoReflect() protoreflect.Message {
+	mi := &file_moego_business_membership_v1_membership_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPerkUsageDetailRequest_Filter.ProtoReflect.Descriptor instead.
+func (*GetPerkUsageDetailRequest_Filter) Descriptor() ([]byte, []int) {
+	return file_moego_business_membership_v1_membership_service_proto_rawDescGZIP(), []int{4, 0}
+}
+
+func (x *GetPerkUsageDetailRequest_Filter) GetValidityStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ValidityStartTime
+	}
+	return nil
+}
+
 var File_moego_business_membership_v1_membership_service_proto protoreflect.FileDescriptor
 
 const file_moego_business_membership_v1_membership_service_proto_rawDesc = "" +
 	"\n" +
-	"5moego/business/membership/v1/membership_service.proto\x12\x1cmoego.business.membership.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a-moego/business/membership/v1/membership.proto\x1a moego/common/v1/pagination.proto\"\xd1\x02\n" +
+	"5moego/business/membership/v1/membership_service.proto\x12\x1cmoego.business.membership.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a-moego/business/membership/v1/membership.proto\x1a moego/common/v1/pagination.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd1\x02\n" +
 	"\x16ListMembershipsRequest\x12@\n" +
 	"\n" +
 	"pagination\x18\x01 \x01(\v2\x1b.moego.common.v1.PaginationB\x03\xe0A\x02R\n" +
@@ -427,10 +602,25 @@ const file_moego_business_membership_v1_membership_service_proto_rawDesc = "" +
 	"\a_filter\"\x95\x01\n" +
 	"\x19ListSubscriptionsResponse\x12P\n" +
 	"\rsubscriptions\x18\x01 \x03(\v2*.moego.business.membership.v1.SubscriptionR\rsubscriptions\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken2\xeb\x02\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xea\x02\n" +
+	"\x19GetPerkUsageDetailRequest\x12[\n" +
+	"\x06filter\x18\x01 \x01(\v2>.moego.business.membership.v1.GetPerkUsageDetailRequest.FilterH\x00R\x06filter\x88\x01\x01\x12\"\n" +
+	"\n" +
+	"company_id\x18\x02 \x01(\tB\x03\xe0A\x02R\tcompanyId\x12(\n" +
+	"\rmembership_id\x18\x03 \x01(\tB\x03\xe0A\x02R\fmembershipId\x12$\n" +
+	"\vcustomer_id\x18\x04 \x01(\tB\x03\xe0A\x02R\n" +
+	"customerId\x1aq\n" +
+	"\x06Filter\x12O\n" +
+	"\x13validity_start_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x11validityStartTime\x88\x01\x01B\x16\n" +
+	"\x14_validity_start_timeB\t\n" +
+	"\a_filter\"\xda\x01\n" +
+	"\x1aGetPerkUsageDetailResponse\x12]\n" +
+	"\x11included_benefits\x18\x01 \x03(\v20.moego.business.membership.v1.IncludeBenefitViewR\x10includedBenefits\x12]\n" +
+	"\x11discount_benefits\x18\x02 \x03(\v20.moego.business.membership.v1.IncludeBenefitViewR\x10discountBenefits2\xa1\x04\n" +
 	"\x11MembershipService\x12\x9f\x01\n" +
 	"\x0fListMemberships\x124.moego.business.membership.v1.ListMembershipsRequest\x1a5.moego.business.membership.v1.ListMembershipsResponse\"\x1f\x82\xd3\xe4\x93\x02\x19:\x01*\"\x14/v1/memberships:list\x12\xb3\x01\n" +
-	"\x11ListSubscriptions\x126.moego.business.membership.v1.ListSubscriptionsRequest\x1a7.moego.business.membership.v1.ListSubscriptionsResponse\"-\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/memberships/subscriptions:listB\xa0\x01\n" +
+	"\x11ListSubscriptions\x126.moego.business.membership.v1.ListSubscriptionsRequest\x1a7.moego.business.membership.v1.ListSubscriptionsResponse\"-\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/memberships/subscriptions:list\x12\xb3\x01\n" +
+	"\x12GetPerkUsageDetail\x127.moego.business.membership.v1.GetPerkUsageDetailRequest\x1a8.moego.business.membership.v1.GetPerkUsageDetailResponse\"*\x82\xd3\xe4\x93\x02$:\x01*\"\x1f/v1/memberships/perkUsageDetailB\xa0\x01\n" +
 	"$com.moego.api.business.membership.v1B\x16MembershipServiceProtoP\x01Z^github.com/MoeGolibrary/moegoapis/genproto/go/business/membership/v1/membershippb;membershippbb\x06proto3"
 
 var (
@@ -445,38 +635,49 @@ func file_moego_business_membership_v1_membership_service_proto_rawDescGZIP() []
 	return file_moego_business_membership_v1_membership_service_proto_rawDescData
 }
 
-var file_moego_business_membership_v1_membership_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_moego_business_membership_v1_membership_service_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_moego_business_membership_v1_membership_service_proto_goTypes = []any{
-	(*ListMembershipsRequest)(nil),          // 0: moego.business.membership.v1.ListMembershipsRequest
-	(*ListMembershipsResponse)(nil),         // 1: moego.business.membership.v1.ListMembershipsResponse
-	(*ListSubscriptionsRequest)(nil),        // 2: moego.business.membership.v1.ListSubscriptionsRequest
-	(*ListSubscriptionsResponse)(nil),       // 3: moego.business.membership.v1.ListSubscriptionsResponse
-	(*ListMembershipsRequest_Filter)(nil),   // 4: moego.business.membership.v1.ListMembershipsRequest.Filter
-	(*ListSubscriptionsRequest_Filter)(nil), // 5: moego.business.membership.v1.ListSubscriptionsRequest.Filter
-	(*commonpb.Pagination)(nil),             // 6: moego.common.v1.Pagination
-	(*Membership)(nil),                      // 7: moego.business.membership.v1.Membership
-	(*Subscription)(nil),                    // 8: moego.business.membership.v1.Subscription
-	(Membership_Status)(0),                  // 9: moego.business.membership.v1.Membership.Status
-	(Subscription_Status)(0),                // 10: moego.business.membership.v1.Subscription.Status
+	(*ListMembershipsRequest)(nil),           // 0: moego.business.membership.v1.ListMembershipsRequest
+	(*ListMembershipsResponse)(nil),          // 1: moego.business.membership.v1.ListMembershipsResponse
+	(*ListSubscriptionsRequest)(nil),         // 2: moego.business.membership.v1.ListSubscriptionsRequest
+	(*ListSubscriptionsResponse)(nil),        // 3: moego.business.membership.v1.ListSubscriptionsResponse
+	(*GetPerkUsageDetailRequest)(nil),        // 4: moego.business.membership.v1.GetPerkUsageDetailRequest
+	(*GetPerkUsageDetailResponse)(nil),       // 5: moego.business.membership.v1.GetPerkUsageDetailResponse
+	(*ListMembershipsRequest_Filter)(nil),    // 6: moego.business.membership.v1.ListMembershipsRequest.Filter
+	(*ListSubscriptionsRequest_Filter)(nil),  // 7: moego.business.membership.v1.ListSubscriptionsRequest.Filter
+	(*GetPerkUsageDetailRequest_Filter)(nil), // 8: moego.business.membership.v1.GetPerkUsageDetailRequest.Filter
+	(*commonpb.Pagination)(nil),              // 9: moego.common.v1.Pagination
+	(*Membership)(nil),                       // 10: moego.business.membership.v1.Membership
+	(*Subscription)(nil),                     // 11: moego.business.membership.v1.Subscription
+	(*IncludeBenefitView)(nil),               // 12: moego.business.membership.v1.IncludeBenefitView
+	(Membership_Status)(0),                   // 13: moego.business.membership.v1.Membership.Status
+	(Subscription_Status)(0),                 // 14: moego.business.membership.v1.Subscription.Status
+	(*timestamppb.Timestamp)(nil),            // 15: google.protobuf.Timestamp
 }
 var file_moego_business_membership_v1_membership_service_proto_depIdxs = []int32{
-	6,  // 0: moego.business.membership.v1.ListMembershipsRequest.pagination:type_name -> moego.common.v1.Pagination
-	4,  // 1: moego.business.membership.v1.ListMembershipsRequest.filter:type_name -> moego.business.membership.v1.ListMembershipsRequest.Filter
-	7,  // 2: moego.business.membership.v1.ListMembershipsResponse.memberships:type_name -> moego.business.membership.v1.Membership
-	6,  // 3: moego.business.membership.v1.ListSubscriptionsRequest.pagination:type_name -> moego.common.v1.Pagination
-	5,  // 4: moego.business.membership.v1.ListSubscriptionsRequest.filter:type_name -> moego.business.membership.v1.ListSubscriptionsRequest.Filter
-	8,  // 5: moego.business.membership.v1.ListSubscriptionsResponse.subscriptions:type_name -> moego.business.membership.v1.Subscription
-	9,  // 6: moego.business.membership.v1.ListMembershipsRequest.Filter.statuses:type_name -> moego.business.membership.v1.Membership.Status
-	10, // 7: moego.business.membership.v1.ListSubscriptionsRequest.Filter.statuses:type_name -> moego.business.membership.v1.Subscription.Status
-	0,  // 8: moego.business.membership.v1.MembershipService.ListMemberships:input_type -> moego.business.membership.v1.ListMembershipsRequest
-	2,  // 9: moego.business.membership.v1.MembershipService.ListSubscriptions:input_type -> moego.business.membership.v1.ListSubscriptionsRequest
-	1,  // 10: moego.business.membership.v1.MembershipService.ListMemberships:output_type -> moego.business.membership.v1.ListMembershipsResponse
-	3,  // 11: moego.business.membership.v1.MembershipService.ListSubscriptions:output_type -> moego.business.membership.v1.ListSubscriptionsResponse
-	10, // [10:12] is the sub-list for method output_type
-	8,  // [8:10] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	9,  // 0: moego.business.membership.v1.ListMembershipsRequest.pagination:type_name -> moego.common.v1.Pagination
+	6,  // 1: moego.business.membership.v1.ListMembershipsRequest.filter:type_name -> moego.business.membership.v1.ListMembershipsRequest.Filter
+	10, // 2: moego.business.membership.v1.ListMembershipsResponse.memberships:type_name -> moego.business.membership.v1.Membership
+	9,  // 3: moego.business.membership.v1.ListSubscriptionsRequest.pagination:type_name -> moego.common.v1.Pagination
+	7,  // 4: moego.business.membership.v1.ListSubscriptionsRequest.filter:type_name -> moego.business.membership.v1.ListSubscriptionsRequest.Filter
+	11, // 5: moego.business.membership.v1.ListSubscriptionsResponse.subscriptions:type_name -> moego.business.membership.v1.Subscription
+	8,  // 6: moego.business.membership.v1.GetPerkUsageDetailRequest.filter:type_name -> moego.business.membership.v1.GetPerkUsageDetailRequest.Filter
+	12, // 7: moego.business.membership.v1.GetPerkUsageDetailResponse.included_benefits:type_name -> moego.business.membership.v1.IncludeBenefitView
+	12, // 8: moego.business.membership.v1.GetPerkUsageDetailResponse.discount_benefits:type_name -> moego.business.membership.v1.IncludeBenefitView
+	13, // 9: moego.business.membership.v1.ListMembershipsRequest.Filter.statuses:type_name -> moego.business.membership.v1.Membership.Status
+	14, // 10: moego.business.membership.v1.ListSubscriptionsRequest.Filter.statuses:type_name -> moego.business.membership.v1.Subscription.Status
+	15, // 11: moego.business.membership.v1.GetPerkUsageDetailRequest.Filter.validity_start_time:type_name -> google.protobuf.Timestamp
+	0,  // 12: moego.business.membership.v1.MembershipService.ListMemberships:input_type -> moego.business.membership.v1.ListMembershipsRequest
+	2,  // 13: moego.business.membership.v1.MembershipService.ListSubscriptions:input_type -> moego.business.membership.v1.ListSubscriptionsRequest
+	4,  // 14: moego.business.membership.v1.MembershipService.GetPerkUsageDetail:input_type -> moego.business.membership.v1.GetPerkUsageDetailRequest
+	1,  // 15: moego.business.membership.v1.MembershipService.ListMemberships:output_type -> moego.business.membership.v1.ListMembershipsResponse
+	3,  // 16: moego.business.membership.v1.MembershipService.ListSubscriptions:output_type -> moego.business.membership.v1.ListSubscriptionsResponse
+	5,  // 17: moego.business.membership.v1.MembershipService.GetPerkUsageDetail:output_type -> moego.business.membership.v1.GetPerkUsageDetailResponse
+	15, // [15:18] is the sub-list for method output_type
+	12, // [12:15] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_moego_business_membership_v1_membership_service_proto_init() }
@@ -486,13 +687,15 @@ func file_moego_business_membership_v1_membership_service_proto_init() {
 	}
 	file_moego_business_membership_v1_membership_proto_init()
 	file_moego_business_membership_v1_membership_service_proto_msgTypes[2].OneofWrappers = []any{}
+	file_moego_business_membership_v1_membership_service_proto_msgTypes[4].OneofWrappers = []any{}
+	file_moego_business_membership_v1_membership_service_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_moego_business_membership_v1_membership_service_proto_rawDesc), len(file_moego_business_membership_v1_membership_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/genproto/go/business/membership/v1/membershippb/membership_service_grpc.pb.go
+++ b/genproto/go/business/membership/v1/membershippb/membership_service_grpc.pb.go
@@ -19,8 +19,9 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	MembershipService_ListMemberships_FullMethodName   = "/moego.business.membership.v1.MembershipService/ListMemberships"
-	MembershipService_ListSubscriptions_FullMethodName = "/moego.business.membership.v1.MembershipService/ListSubscriptions"
+	MembershipService_ListMemberships_FullMethodName    = "/moego.business.membership.v1.MembershipService/ListMemberships"
+	MembershipService_ListSubscriptions_FullMethodName  = "/moego.business.membership.v1.MembershipService/ListSubscriptions"
+	MembershipService_GetPerkUsageDetail_FullMethodName = "/moego.business.membership.v1.MembershipService/GetPerkUsageDetail"
 )
 
 // MembershipServiceClient is the client API for MembershipService service.
@@ -45,6 +46,13 @@ type MembershipServiceClient interface {
 	// - INVALID_ARGUMENT if pagination parameters are invalid
 	// - PERMISSION_DENIED if the caller lacks access rights
 	ListSubscriptions(ctx context.Context, in *ListSubscriptionsRequest, opts ...grpc.CallOption) (*ListSubscriptionsResponse, error)
+	// GetPerkUsageDetail retrieves detailed information about perk usage for a specific membership.
+	//
+	// Possible errors:
+	// - INVALID_ARGUMENT if the request parameters are invalid
+	// - NOT_FOUND if the membership or customer is not found
+	// - PERMISSION_DENIED if the caller lacks access rights
+	GetPerkUsageDetail(ctx context.Context, in *GetPerkUsageDetailRequest, opts ...grpc.CallOption) (*GetPerkUsageDetailResponse, error)
 }
 
 type membershipServiceClient struct {
@@ -75,6 +83,16 @@ func (c *membershipServiceClient) ListSubscriptions(ctx context.Context, in *Lis
 	return out, nil
 }
 
+func (c *membershipServiceClient) GetPerkUsageDetail(ctx context.Context, in *GetPerkUsageDetailRequest, opts ...grpc.CallOption) (*GetPerkUsageDetailResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetPerkUsageDetailResponse)
+	err := c.cc.Invoke(ctx, MembershipService_GetPerkUsageDetail_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MembershipServiceServer is the server API for MembershipService service.
 // All implementations must embed UnimplementedMembershipServiceServer
 // for forward compatibility.
@@ -97,6 +115,13 @@ type MembershipServiceServer interface {
 	// - INVALID_ARGUMENT if pagination parameters are invalid
 	// - PERMISSION_DENIED if the caller lacks access rights
 	ListSubscriptions(context.Context, *ListSubscriptionsRequest) (*ListSubscriptionsResponse, error)
+	// GetPerkUsageDetail retrieves detailed information about perk usage for a specific membership.
+	//
+	// Possible errors:
+	// - INVALID_ARGUMENT if the request parameters are invalid
+	// - NOT_FOUND if the membership or customer is not found
+	// - PERMISSION_DENIED if the caller lacks access rights
+	GetPerkUsageDetail(context.Context, *GetPerkUsageDetailRequest) (*GetPerkUsageDetailResponse, error)
 	mustEmbedUnimplementedMembershipServiceServer()
 }
 
@@ -112,6 +137,9 @@ func (UnimplementedMembershipServiceServer) ListMemberships(context.Context, *Li
 }
 func (UnimplementedMembershipServiceServer) ListSubscriptions(context.Context, *ListSubscriptionsRequest) (*ListSubscriptionsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListSubscriptions not implemented")
+}
+func (UnimplementedMembershipServiceServer) GetPerkUsageDetail(context.Context, *GetPerkUsageDetailRequest) (*GetPerkUsageDetailResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetPerkUsageDetail not implemented")
 }
 func (UnimplementedMembershipServiceServer) mustEmbedUnimplementedMembershipServiceServer() {}
 func (UnimplementedMembershipServiceServer) testEmbeddedByValue()                           {}
@@ -170,6 +198,24 @@ func _MembershipService_ListSubscriptions_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MembershipService_GetPerkUsageDetail_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetPerkUsageDetailRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MembershipServiceServer).GetPerkUsageDetail(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MembershipService_GetPerkUsageDetail_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MembershipServiceServer).GetPerkUsageDetail(ctx, req.(*GetPerkUsageDetailRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MembershipService_ServiceDesc is the grpc.ServiceDesc for MembershipService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -184,6 +230,10 @@ var MembershipService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListSubscriptions",
 			Handler:    _MembershipService_ListSubscriptions_Handler,
+		},
+		{
+			MethodName: "GetPerkUsageDetail",
+			Handler:    _MembershipService_GetPerkUsageDetail_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/moego/business/membership/v1/membership.proto
+++ b/moego/business/membership/v1/membership.proto
@@ -222,3 +222,81 @@ message TimePeriod {
   // The value of the period in the specified unit.
   int32 value = 2;
 }
+
+// IncludeBenefitView represents a membership benefit view.
+message IncludeBenefitView {
+  // history id
+  string id = 1;
+  
+  // membership id
+  string membership_id = 2;
+  
+  // quantity
+  int32 total_quantity = 3;
+  
+  // remaining quantity
+  int32 remaining_quantity = 4;
+  
+  // is limited
+  bool is_limited = 5;
+  
+  // redeem time
+  google.protobuf.Timestamp redeem_time = 6;
+  
+  // item detail def
+  message RedeemItemDetailView {
+    // item id
+    string item_id = 1;
+    
+    // item name
+    string item_name = 2;
+    
+    // item amount
+    google.type.Money price = 3;
+    
+    // item type
+    TargetType item_type = 4;
+  }
+  
+  // item details
+  repeated RedeemItemDetailView item_details = 7;
+  
+  // is all
+  bool is_all = 8;
+  
+  // discount unit
+  DiscountUnit discount_unit = 9;
+  
+  // discount value
+  double discount_value = 10;
+}
+
+// TargetType represents the type of target for membership benefits.
+enum TargetType {
+  // unspecified
+  TARGET_TYPE_UNSPECIFIED = 0;
+  
+  // service
+  SERVICE = 1;
+  
+  // add on
+  ADDON = 2;
+  
+  // product
+  PRODUCT = 3;
+  
+  // package
+  PACKAGE = 4;
+}
+
+// DiscountUnit represents the unit of discount for membership benefits.
+enum DiscountUnit {
+  // unspecified
+  UNIT_UNSPECIFIED = 0;
+  
+  // percent
+  PERCENT = 1;
+  
+  // numerical
+  NUMERICAL = 2;
+}

--- a/moego/business/membership/v1/membership_service.proto
+++ b/moego/business/membership/v1/membership_service.proto
@@ -6,6 +6,7 @@ import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "moego/business/membership/v1/membership.proto";
 import "moego/common/v1/pagination.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/MoeGolibrary/moegoapis/genproto/go/business/membership/v1/membershippb;membershippb";
 option java_multiple_files = true;
@@ -38,6 +39,19 @@ service MembershipService {
   rpc ListSubscriptions(ListSubscriptionsRequest) returns (ListSubscriptionsResponse) {
     option (google.api.http) = {
       post: "/v1/memberships/subscriptions:list"
+      body: "*"
+    };
+  }
+  
+  // GetPerkUsageDetail retrieves detailed information about perk usage for a specific membership.
+  //
+  // Possible errors:
+  // - INVALID_ARGUMENT if the request parameters are invalid
+  // - NOT_FOUND if the membership or customer is not found
+  // - PERMISSION_DENIED if the caller lacks access rights
+  rpc GetPerkUsageDetail(GetPerkUsageDetailRequest) returns (GetPerkUsageDetailResponse) {
+    option (google.api.http) = {
+      post: "/v1/memberships/perkUsageDetail"
       body: "*"
     };
   }
@@ -119,4 +133,34 @@ message ListSubscriptionsResponse {
   // Obtained from the previous page's response.
   // Empty if there are no more results.
   string next_page_token = 2;
+}
+
+// The request message for getting perk usage detail
+message GetPerkUsageDetailRequest {
+  // Filter parameters
+  message Filter {
+    // Validity start time
+    optional google.protobuf.Timestamp validity_start_time = 1;
+  }
+  
+  // Optional filter
+  optional Filter filter = 1;
+  
+  // The company identifier
+  string company_id = 2 [(google.api.field_behavior) = REQUIRED];
+  
+  // The membership identifier
+  string membership_id = 3 [(google.api.field_behavior) = REQUIRED];
+  
+  // The customer identifier
+  string customer_id = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The response message for getting perk usage detail
+message GetPerkUsageDetailResponse {
+  // The included benefits
+  repeated IncludeBenefitView included_benefits = 1;
+  
+  // Discount benefits
+  repeated IncludeBenefitView discount_benefits = 2;
 }


### PR DESCRIPTION
- Added GetPerkUsageDetail RPC endpoint with request/response messages
- Defined IncludeBenefitView and RedeemItemDetailView protobuf messages
- Introduced TargetType and DiscountUnit enums for membership benefits
- Updated swagger documentation for new API endpoint
- Extended membership service with perk usage functionality