### PR TITLE
docs(changelog): add abandonPreference entry GRM-1616

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,10 +19,12 @@ When making API changes:
 - `Appointment:Create` API: added `lodgingId` field to `CreateAppointmentRequest.Service` to support lodging unit assignment for `BOARDING`/`DAYCARE` appointments (2026-03-31)
 - `Appointment:Create` API: support `BOARDING` and `DAYCARE` service types; `staffIds` is no longer required for boarding/daycare (2026-03-31)
 - `Appointment:Create` API: added optional `price` field to `CreateAppointmentRequest.Service`; if not set, system default price is used (2026-04-01)
+- `AbandonedBooking:Get` and `AbandonedBooking:List` APIs: added optional `abandonPreference` field on `AbandonedBooking` capturing the preference snapshot submitted during the abandon flow; includes `preferredDay` (`TODAY` | `TOMORROW` | `THIS_WEEK` | `FLEXIBLE`), `preferredTime` (`MORNING` | `AFTERNOON` | `EITHER`), and `preferenceSubmittedAt` timestamp; field is omitted when the customer did not submit a preference (2026-05-12)
 
 ### Documentation
 - `Appointment:Create` API: clarified per-type field requirements for `Service` object; added boarding and daycare examples (2026-03-31)
 - `Appointment:Create` API: documented `price` field (2026-04-01)
+- `AbandonedBooking`: documented `abandonPreference` field with nested `AbandonPreference` message, `PreferredDay` and `PreferredTime` enums (2026-05-12)
 
 ---
 


### PR DESCRIPTION
## Summary
- Document the `abandonPreference` field shipped in #73 (commit `346c08f`) under `[Unreleased]` in `docs/CHANGELOG.md`.
- The field is a backward-compatible MINOR addition on `AbandonedBooking`, exposed by `GetAbandonedBooking` and `ListAbandonedBookings`.
- Adds both the API-side entry (`### Added`) and the doc-side entry (`### Documentation`) to match the existing changelog conventions.

## Why
The proto + `docs/online_booking.md` were updated in #73, but `docs/CHANGELOG.md` was not. This means the public site at `https://moegolibrary.github.io/moegoapis/docs/CHANGELOG.html` is missing this entry.

## Test plan
- [ ] Review rendered diff in `docs/CHANGELOG.md`
- [ ] After merge to `production`, confirm the new bullet appears at `https://moegolibrary.github.io/moegoapis/docs/CHANGELOG.html` once GitHub Pages rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)