### PR TITLE
docs(order): clarify read-only order api

### DIFF
--- a/docs/order.md
+++ b/docs/order.md
@@ -5,7 +5,7 @@
 Order represents a financial transaction for services provided to a customer. This module provides the following
 functions:
 
-- Creating, retrieving, and updating order details
+- Retrieving order details
 - Listing orders with support for filtering (by business ID, status, and update time)
 - Managing order line items representing individual services or products
 - Tracking comprehensive financial details including subtotal, tax, tips, discounts, fees, total amount, paid amount,
@@ -543,6 +543,7 @@ TODO
 
 | Question                                                | Answer                                                                                   |
 |---------------------------------------------------------|------------------------------------------------------------------------------------------|
+| Can I create or update an order through this API?       | No. Orders are created and updated by MoeGo appointment and checkout flows               |
 | How to verify if an order exists?                       | Use `GetOrder` to check if the order ID returns a valid response                         |
 | Can I list orders for multiple companies at once?       | Currently only supports listing orders for one company at a time                         |
 | How to filter orders by business location?              | Use `ListOrders` with `businessIds`                                                      |

--- a/moego/business/order/v1/order_service.proto
+++ b/moego/business/order/v1/order_service.proto
@@ -16,9 +16,10 @@ option java_multiple_files = true;
 option java_outer_classname = "OrderProto";
 option java_package = "com.moego.api.business.order.v1";
 
-// OrderService provides methods for managing orders and their line items.
-// This service handles the creation, retrieval, and listing of orders and
-// their associated items. It supports filtering and pagination for efficient
+// OrderService provides read-only methods for retrieving orders and listing
+// their associated items.
+// This service handles the retrieval and listing of orders and their
+// associated items. It supports filtering and pagination for efficient
 // data access and reporting.
 service OrderService {
   // Retrieves detailed information about a specific order.


### PR DESCRIPTION
- Remove misleading "Creating" wording from order overview\n- Add FAQ entry clarifying orders are not created or updated through this API\n\nThis keeps the public docs aligned with the read-only Order API contract.