### PR TITLE
docs(openapi): align availability and DeleteBlock docs (COO-16)

### DIFF
--- a/docs/block.md
+++ b/docs/block.md
@@ -60,7 +60,7 @@ Here is a typical integration flow:
     - Verify block configuration and check time conflicts
 
 3. **Schedule Management & Monitoring**
-    - Regularly create and update blocks to manage staff availability
+    - Regularly create and delete blocks to manage staff availability
     - Use blocks to prevent scheduling conflicts
     - Monitor staff schedules across multiple business locations
 
@@ -193,6 +193,39 @@ Retrieves a list of blocks based on the provided filter criteria.
 
 ---
 
+### 4. DeleteBlock (`DeleteBlock`)
+
+- **Method**: `DeleteBlock`
+- **HTTP Method**: DELETE
+- **Path**: `/v1/blocks/{id}`
+
+#### ✅ Functionality:
+
+Soft-deletes a block. After deletion, the block no longer appears in `ListBlocks` and no longer blocks that time on the staff member's schedule.
+
+#### 🎯 Use Cases:
+
+- Removing a block that should no longer reserve staff time
+- Releasing blocked time before creating a replacement block at a different time
+
+#### 🔧 Request Parameters:
+
+| Field Name | Type   | Required | Description                               |
+|------------|--------|----------|-------------------------------------------|
+| `id`       | string | Yes      | Unique identifier of the block to delete |
+
+#### 📌 Return Value:
+
+Returns an empty JSON object (`{}`) when the deletion succeeds.
+
+#### ⚠️ Error Codes:
+
+- `NOT_FOUND`: The block does not exist or has already been deleted
+- `INVALID_ARGUMENT`: The block ID format is invalid
+- `PERMISSION_DENIED`: Permission denied
+
+---
+
 ## 🧪 6. Usage Examples
 
 ### Example 1: CreateBlock
@@ -218,11 +251,24 @@ Retrieves a list of blocks based on the provided filter criteria.
 }
 ```
 
+### Example 3: DeleteBlock
+
+```http
+DELETE /v1/blocks/block_001
+```
+
+**Response:**
+
+```json
+{}
+```
+
 ---
 
 ## ⚠️ 7. Usage Limitations
 
-TODO
+- The public API does not provide `UpdateBlock`. To move a block, delete the existing block and create a new one. The newly created block has a new ID.
+- Deletion is soft. The deleted block is removed from `ListBlocks`; `GetBlock` may still return the existing record by ID. Use `ListBlocks` to determine which blocks are active on the schedule.
 
 ---
 

--- a/docs/online_booking.md
+++ b/docs/online_booking.md
@@ -312,6 +312,8 @@ constraints. This endpoint helps customers find suitable time slots when booking
 - For mobile businesses with smart scheduling enabled, location parameters (coordinate or zipcode) are **required**
 - If location parameters are missing for mobile businesses with smart scheduling, the API will return an error
 - For fixed-location businesses, location parameters are optional but recommended for better availability results
+- Dates must use the `google.type.Date` JSON format, for example `{ "year": 2026, "month": 8, "day": 28 }`; date strings are invalid
+- `startDate` defaults to today and `endDate` defaults to `startDate`. HTTP 200 may contain empty arrays when no slot matches that day
 
 #### 🔧 Request Parameters
 
@@ -319,13 +321,13 @@ constraints. This endpoint helps customers find suitable time slots when booking
 |--------------|--------|----------|----------------------------------------------|
 | `companyId`  | string | Yes      | Company identifier for multi-tenancy support |
 | `businessId` | string | Yes      | Business location where services provided    |
-| `filter`     | object | No       | Filter parameters for the availability check |
+| `filter`     | object | No       | Optional filters; when omitted, availability is queried for today only |
 
 ##### Filter Options:
 
-- `startDate`: Start date for availability check (defaults to today). Maximum range between startDate and endDate is 3
+- `startDate`: Start date as a `google.type.Date` object (defaults to today). Maximum range between startDate and endDate is 3
   months.
-- `endDate`: End date for availability check (defaults to startDate). Maximum range between startDate and endDate is 3
+- `endDate`: End date as a `google.type.Date` object (defaults to startDate). Maximum range between startDate and endDate is 3
   months.
 - `serviceIds`: Filter by specific service IDs
 - `staffIds`: Filter by specific staff IDs
@@ -336,7 +338,7 @@ constraints. This endpoint helps customers find suitable time slots when booking
 - `zipcode`: Filter by postal code
   - **Required** for mobile businesses with smart scheduling
   - Used for territory-based routing and service area validation
-- `pets`: Array of pet parameters including:
+- `pets`: Optional array of pet parameters. It is not required when `filter.serviceIds` is provided:
     - `id`: Pet ID (for existing pets)
     - `name`: Pet name
     - `type`: Pet type/species (see Pet Types table below)
@@ -588,7 +590,12 @@ POST /v1/online_booking/availability
 ```json
 {
   "companyId": "cmp_001",
-  "businessId": "biz_001"
+  "businessId": "biz_001",
+  "filter": {
+    "startDate": { "year": 2026, "month": 8, "day": 28 },
+    "endDate": { "year": 2026, "month": 9, "day": 4 },
+    "serviceIds": ["svc_123"]
+  }
 }
 ```
 
@@ -597,13 +604,13 @@ POST /v1/online_booking/availability
 ```json
 {
   "availableDates": [
-    "2024-08-20",
-    "2024-08-21",
-    "2024-08-22"
+    { "year": 2026, "month": 8, "day": 28 },
+    { "year": 2026, "month": 8, "day": 29 },
+    { "year": 2026, "month": 8, "day": 30 }
   ],
   "availability": [
     {
-      "date": "2024-08-20",
+      "date": { "year": 2026, "month": 8, "day": 28 },
       "staff": [
         {
           "staffId": "stf_123",
@@ -682,8 +689,8 @@ POST /v1/online_booking/availability
   "companyId": "cmp_001",
   "businessId": "biz_001",
   "filter": {
-    "startDate": "2024-08-20",
-    "endDate": "2024-08-22",
+    "startDate": { "year": 2026, "month": 8, "day": 28 },
+    "endDate": { "year": 2026, "month": 8, "day": 30 },
     "serviceIds": [
       "svc_123"
     ],
@@ -705,12 +712,12 @@ POST /v1/online_booking/availability
 ```json
 {
   "availableDates": [
-    "2024-08-20",
-    "2024-08-21"
+    { "year": 2026, "month": 8, "day": 28 },
+    { "year": 2026, "month": 8, "day": 29 }
   ],
   "availability": [
     {
-      "date": "2024-08-20",
+      "date": { "year": 2026, "month": 8, "day": 28 },
       "staff": [
         {
           "staffId": "stf_123",

--- a/docs/online_booking.md
+++ b/docs/online_booking.md
@@ -321,13 +321,13 @@ constraints. This endpoint helps customers find suitable time slots when booking
 |--------------|--------|----------|----------------------------------------------|
 | `companyId`  | string | Yes      | Company identifier for multi-tenancy support |
 | `businessId` | string | Yes      | Business location where services provided    |
-| `filter`     | object | No       | Optional filters; when omitted, availability is queried for today only |
+| `filter`     | object | No       | When omitted, availability is queried for today only |
 
 ##### Filter Options:
 
-- `startDate`: Start date as a `google.type.Date` object (defaults to today). Maximum range between startDate and endDate is 3
+- `startDate`: Start date for availability check (defaults to today). Maximum range between startDate and endDate is 3
   months.
-- `endDate`: End date as a `google.type.Date` object (defaults to startDate). Maximum range between startDate and endDate is 3
+- `endDate`: End date for availability check (defaults to startDate). Maximum range between startDate and endDate is 3
   months.
 - `serviceIds`: Filter by specific service IDs
 - `staffIds`: Filter by specific staff IDs

--- a/docs/openapi/moego/business/block/v1/block_service.swagger.json
+++ b/docs/openapi/moego/business/block/v1/block_service.swagger.json
@@ -85,7 +85,7 @@
       },
       "delete": {
         "summary": "DeleteBlock deletes (cancels) a block from a staff member's schedule.\nThe block is soft-deleted and the time slot becomes available for booking.",
-        "description": "Returns:\n- Successfully if the deletion is completed\n- NOT_FOUND if the block doesn't exist\n- INVALID_ARGUMENT if the block is already canceled\n- PERMISSION_DENIED if the caller lacks permission",
+        "description": "Returns:\n- Successfully if the deletion is completed\n- NOT_FOUND if the block doesn't exist or has already been deleted\n- INVALID_ARGUMENT if the block ID format is invalid\n- PERMISSION_DENIED if the caller lacks permission",
         "operationId": "BlockService_DeleteBlock",
         "responses": {
           "200": {

--- a/genproto/go/business/block/v1/blockpb/block_service_grpc.pb.go
+++ b/genproto/go/business/block/v1/blockpb/block_service_grpc.pb.go
@@ -59,8 +59,8 @@ type BlockServiceClient interface {
 	//
 	// Returns:
 	// - Successfully if the deletion is completed
-	// - NOT_FOUND if the block doesn't exist
-	// - INVALID_ARGUMENT if the block is already canceled
+	// - NOT_FOUND if the block doesn't exist or has already been deleted
+	// - INVALID_ARGUMENT if the block ID format is invalid
 	// - PERMISSION_DENIED if the caller lacks permission
 	DeleteBlock(ctx context.Context, in *DeleteBlockRequest, opts ...grpc.CallOption) (*DeleteBlockResponse, error)
 }
@@ -147,8 +147,8 @@ type BlockServiceServer interface {
 	//
 	// Returns:
 	// - Successfully if the deletion is completed
-	// - NOT_FOUND if the block doesn't exist
-	// - INVALID_ARGUMENT if the block is already canceled
+	// - NOT_FOUND if the block doesn't exist or has already been deleted
+	// - INVALID_ARGUMENT if the block ID format is invalid
 	// - PERMISSION_DENIED if the caller lacks permission
 	DeleteBlock(context.Context, *DeleteBlockRequest) (*DeleteBlockResponse, error)
 	mustEmbedUnimplementedBlockServiceServer()

--- a/moego/business/block/v1/block_service.proto
+++ b/moego/business/block/v1/block_service.proto
@@ -58,8 +58,8 @@ service BlockService {
   //
   // Returns:
   // - Successfully if the deletion is completed
-  // - NOT_FOUND if the block doesn't exist
-  // - INVALID_ARGUMENT if the block is already canceled
+  // - NOT_FOUND if the block doesn't exist or has already been deleted
+  // - INVALID_ARGUMENT if the block ID format is invalid
   // - PERMISSION_DENIED if the caller lacks permission
   rpc DeleteBlock(DeleteBlockRequest) returns (DeleteBlockResponse) {
     option (google.api.http) = {delete: "/v1/blocks/{id}"};


### PR DESCRIPTION
## Summary

- align availability date examples with the `google.type.Date` JSON shape and document default single-day behavior
- add the existing DeleteBlock endpoint to the handwritten Block API guide, including soft-delete and move semantics
- align DeleteBlock proto, Swagger, and generated Go comments with the recorded `NOT_FOUND` / `INVALID_ARGUMENT` behavior

Tracks COO-16. This PR does not change runtime behavior, schemas, RPCs, field numbers, or HTTP annotations.

## Validation

- `make pb` — exit 0; non-required generator noise excluded, leaving the five frozen-scope files
- scoped U-02..U-07 and E-01..E-07 verification — exit 0
- `buf breaking --against '.git#branch=origin/production'` — exit 0
- `git diff --check` — exit 0
- `make format-lint` — exits 2 after existing `buf lint` findings in untouched `moego/business/customer/v1/customer.proto:253-257` (five fields without comments); formatting completed before lint stopped

No production write verification was run; this documentation-only change relies on the production evidence frozen in COO-16.
